### PR TITLE
ContactPicker: load images asynchornously

### DIFF
--- a/WalkingChallenge/ContactPicker.swift
+++ b/WalkingChallenge/ContactPicker.swift
@@ -50,10 +50,12 @@ class ContactCell: UITableViewCell {
 
   func configure(info: ContactCellInfo) {
     name.text = info.name
-    do {
-      let data = try Data(contentsOf: URL(string: info.picture)!)
-      picture.image = UIImage(data: data)
-    } catch {
+    onBackground {
+      do {
+        let data = try Data(contentsOf: URL(string: info.picture)!)
+        self.picture.image = UIImage(data: data)
+      } catch {
+      }
     }
   }
 }

--- a/WalkingChallenge/TeamMemberCell.swift
+++ b/WalkingChallenge/TeamMemberCell.swift
@@ -55,10 +55,12 @@ class TeamMemberCell: ConfigurableTableViewCell {
 
     nameLabel.text = cell.name
 
-    do {
-      let data = try Data(contentsOf: URL(string: cell.picture)!)
-      picture.image = UIImage(data: data)
-    } catch {
+    onBackground {
+      do {
+        let data = try Data(contentsOf: URL(string: cell.picture)!)
+        self.picture.image = UIImage(data: data)
+      } catch {
+      }
     }
   }
 }


### PR DESCRIPTION
Loading network content on the main thread will destroy performance.
Load the images asynchronously.  Makes the contact picker significantly
smoother.