### PR TITLE
collapse IdentifiedUITableViewCell and ConfigurableUITableViewCell

### DIFF
--- a/WalkingChallenge/Cells.swift
+++ b/WalkingChallenge/Cells.swift
@@ -29,12 +29,16 @@
 
 import UIKit
 
-protocol IdentifiedUITableViewCell {
+protocol ConfigurableUITableViewCell {
   static var identifier: String { get }
+  func configure(_: Any)
 }
 
-protocol ConfigurableUITableViewCell {
-  func configure(_: Any)
+extension UITableView {
+  func register<T: ConfigurableUITableViewCell>(_ type: T.Type)
+      where T: UITableViewCell {
+    register(type, forCellReuseIdentifier: type.identifier)
+  }
 }
 
 protocol CellInfo {

--- a/WalkingChallenge/EventsViewController.swift
+++ b/WalkingChallenge/EventsViewController.swift
@@ -35,9 +35,7 @@ protocol EventCellDelegate: class {
   func join(event: Event)
 }
 
-fileprivate class EventCell: UITableViewCell, IdentifiedUITableViewCell {
-  static let identifier: String = "EventCell"
-
+fileprivate class EventCell: UITableViewCell {
   internal var imgImage: UIImageView = UIImageView()
   internal var lblEventName: UILabel = UILabel()
   internal var lblCause: UILabel = UILabel()
@@ -103,6 +101,8 @@ fileprivate class EventCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension EventCell: ConfigurableUITableViewCell {
+  static let identifier: String = "EventCell"
+
   func configure(_ data: Any) {
     guard
       let (event, delegate) = data as? (Event, EventCellDelegate)
@@ -218,8 +218,7 @@ class EventsViewController: UIViewController {
     tblTableView.dataSource = events
     tblTableView.estimatedRowHeight = 2
     tblTableView.rowHeight = UITableViewAutomaticDimension
-    tblTableView.register(EventCell.self,
-                          forCellReuseIdentifier: EventCell.identifier)
+    tblTableView.register(EventCell.self)
 
     AKFCausesService.getEvents { [weak self] (result) in
       switch result {

--- a/WalkingChallenge/Leaderboard.swift
+++ b/WalkingChallenge/Leaderboard.swift
@@ -38,9 +38,7 @@ struct LeaderBoardEntry {
   let raised: Float
 }
 
-class LeaderBoardCell: UITableViewCell, IdentifiedUITableViewCell {
-  static var identifier: String = "LeaderBoardCell"
-
+class LeaderBoardCell: UITableViewCell {
   internal var standing: UILabel = UILabel(.header)
   internal var picture: UIImageView = UIImageView()
   internal var name: UILabel = UILabel(.body)
@@ -99,6 +97,8 @@ class LeaderBoardCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension LeaderBoardCell: ConfigurableUITableViewCell {
+  static let identifier: String = "LeaderBoardCell"
+
   func configure(_ data: Any) {
     guard let info = data as? LeaderBoardEntry else { return }
 
@@ -122,8 +122,7 @@ class LeaderBoard: UITableView {
     self.allowsSelection = false
     self.dataSource = self
     self.separatorStyle = .none
-    self.register(LeaderBoardCell.self,
-                  forCellReuseIdentifier: LeaderBoardCell.identifier)
+    self.register(LeaderBoardCell.self)
   }
 }
 

--- a/WalkingChallenge/SupportersViewController.swift
+++ b/WalkingChallenge/SupportersViewController.swift
@@ -30,9 +30,7 @@
 import UIKit
 import SnapKit
 
-class SponsorCell: UITableViewCell, IdentifiedUITableViewCell {
-  static let identifier: String = "SponsorCell"
-
+class SponsorCell: UITableViewCell {
   internal var picture: UIImageView = UIImageView()
   internal var name: UILabel = UILabel(.body)
   internal var tagline: UILabel = UILabel(.caption)
@@ -85,6 +83,8 @@ class SponsorCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension SponsorCell: ConfigurableUITableViewCell {
+  static let identifier: String = "SponsorCell"
+
   func configure(_ data: Any) {
     guard let info = data as? Sponsor else { return }
 
@@ -127,9 +127,7 @@ fileprivate class SponsorsDataSource: NSObject, UITableViewDataSource {
   }
 }
 
-class SupporterCell: UITableViewCell, IdentifiedUITableViewCell {
-  static let identifier: String = "SupporterCell"
-
+class SupporterCell: UITableViewCell {
   internal var name: UILabel = UILabel(.body)
   internal var donated: UILabel = UILabel(.body)
   internal var pledged: UILabel = UILabel(.caption)
@@ -168,6 +166,8 @@ class SupporterCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension SupporterCell: ConfigurableUITableViewCell {
+  static let identifier: String = "SupporterCell"
+
   func configure(_ data: Any) {
     guard let info = data as? Supporter else { return }
 
@@ -293,8 +293,7 @@ class SupportersViewController: UIViewController {
     tblSponsorsTable.allowsSelection = false
     tblSponsorsTable.estimatedRowHeight = 50 //This is an arbitrary number
     tblSponsorsTable.rowHeight = UITableViewAutomaticDimension
-    tblSponsorsTable.register(SponsorCell.self,
-                              forCellReuseIdentifier: SponsorCell.identifier)
+    tblSponsorsTable.register(SponsorCell.self)
     tblSponsorsTable.snp.makeConstraints { (make) in
       make.top.equalTo(top).offset(Style.Padding.p8)
       make.leading.trailing.equalToSuperview().inset(Style.Padding.p12)
@@ -332,8 +331,7 @@ class SupportersViewController: UIViewController {
     view.addSubview(tblSupportersTable)
     tblSupportersTable.dataSource = supportersDataSource
     tblSupportersTable.allowsSelection = false
-    tblSupportersTable.register(SupporterCell.self,
-                                forCellReuseIdentifier: SupporterCell.identifier)
+    tblSupportersTable.register(SupporterCell.self)
     tblSupportersTable.snp.makeConstraints { (make) in
       make.top.equalTo(top).offset(Style.Padding.p8)
       make.leading.trailing.equalToSuperview().inset(Style.Padding.p12)

--- a/WalkingChallenge/TeamMembersViewController.swift
+++ b/WalkingChallenge/TeamMembersViewController.swift
@@ -39,9 +39,7 @@ struct TeamMemberCountInfo: CellInfo {
   }
 }
 
-class TeamMemberCountCell: UITableViewCell, IdentifiedUITableViewCell {
-  static var identifier: String = "TeamMemberCountCell"
-
+class TeamMemberCountCell: UITableViewCell {
   let label: UILabel = UILabel(.header)
 
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
@@ -64,6 +62,8 @@ class TeamMemberCountCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension TeamMemberCountCell: ConfigurableUITableViewCell {
+  static let identifier: String = "TeamMemberCountCell"
+
   func configure(_ data: Any) {
     guard let info = data as? TeamMemberCountInfo else { return }
     // TODO(compnerd) make this localisable
@@ -81,9 +81,7 @@ struct TeamMemberInfo: CellInfo {
   }
 }
 
-class TeamMemberCell: UITableViewCell, IdentifiedUITableViewCell {
-  static let identifier: String = "TeamMemberCell"
-
+class TeamMemberCell: UITableViewCell {
   let pictureView = UIImageView()
   let nameLabel = UILabel(.body)
 
@@ -122,6 +120,8 @@ class TeamMemberCell: UITableViewCell, IdentifiedUITableViewCell {
 }
 
 extension TeamMemberCell: ConfigurableUITableViewCell {
+  static let identifier: String = "TeamMemberCell"
+
   func configure(_ data: Any) {
     guard let info = data as? TeamMemberInfo else { return }
     Facebook.getRealName(for: info.member.fbid) { [weak self] (name) in
@@ -214,10 +214,8 @@ class TeamMembersViewController: UIViewController {
 
     tableView.allowsSelection = false
     tableView.dataSource = teamMembersDataSource
-    tableView.register(TeamMemberCountCell.self,
-                       forCellReuseIdentifier: TeamMemberCountCell.identifier)
-    tableView.register(TeamMemberCell.self,
-                       forCellReuseIdentifier: TeamMemberCell.identifier)
+    tableView.register(TeamMemberCountCell.self)
+    tableView.register(TeamMemberCell.self)
     tableView.snp.makeConstraints { (make) in
       make.leading.trailing.equalToSuperview().inset(Style.Padding.p12)
       make.top.equalToSuperview().inset(Style.Padding.p12)


### PR DESCRIPTION
Collapse these into a single protocol allowing for a simpler extension
that defines both pieces.  Take the opportunity to add an extension to
UITableView to register a ConfigurableUITableViewCell (we can get the
identifier from the protocol conformance).