### PR TITLE
CreateTeam: actually manage the team

### DIFF
--- a/WalkingChallenge/AKFCausesService.swift
+++ b/WalkingChallenge/AKFCausesService.swift
@@ -109,8 +109,23 @@ class AKFCausesService: Service {
     shared.request(endpoint: .participant(fbid), completion: completion)
   }
 
+  static func createTeam(name: String, completion: ServiceRequestCompletion? = nil) {
+    shared.request(.post, endpoint: .teams, parameters: JSON(["name": name]),
+                   completion: completion)
+  }
+
+  static func deleteTeam(team: Int, completion: ServiceRequestCompletion? = nil) {
+    shared.request(.delete, endpoint: .team(team), completion: completion)
+  }
+
   static func getTeam(team: Int, completion: ServiceRequestCompletion? = nil) {
     shared.request(endpoint: .team(team), completion: completion)
+  }
+
+  static func joinTeam(fbid: String, team: Int,
+                       completion: ServiceRequestCompletion? = nil) {
+    shared.request(.patch, endpoint: .participant(fbid),
+                   parameters: JSON(["team_id": team]), completion: completion)
   }
 
   static func performAPIHealthCheck(completion: ServiceRequestCompletion? = nil) {


### PR DESCRIPTION
We can now create and delete the team.  Additionally, we now add members
to the team itself.  Unfortunately, the team validation bit is not yet
ready, but this allows us to play with more of the app flow.