### PR TITLE
Dashboard: fix team label size

### DIFF
--- a/WalkingChallenge/Dashboard/ProfileCard.swift
+++ b/WalkingChallenge/Dashboard/ProfileCard.swift
@@ -100,6 +100,7 @@ class ProfileCardView: StylizedCardView {
       $0.top.equalTo(lblChallenge.snp.bottom).offset(Style.Padding.p2)
       $0.left.equalTo(lblChallenge.snp.left)
     }
+    lblTeamLabel.setContentHuggingPriority(.required, for: .horizontal)
 
     lblTeam.snp.makeConstraints {
       $0.top.equalTo(lblChallenge.snp.bottom).offset(Style.Padding.p2)


### PR DESCRIPTION
Set the content hugging policy to ensure that the labelling label is
shrunk to fit the content.