### PR TITLE
Configuration: add test URL to the permitted set

### DIFF
--- a/Steps4Impact/Supporting Files/Info.plist
+++ b/Steps4Impact/Supporting Files/Info.plist
@@ -55,7 +55,7 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
-			<key>sultan.step4change.org</key>
+			<key>akf-causes.subshell.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
This is needed to allow testing against a developer instance.