### PR TITLE
settings: wire up leave team

### DIFF
--- a/Steps4Impact/App/LocalizedStrings.swift
+++ b/Steps4Impact/App/LocalizedStrings.swift
@@ -242,6 +242,14 @@ Click continue for a quick tour of the app.
       NSLocalizedString("Team", comment: "Team settings screen title")
     static let edit: String =
       NSLocalizedString("Edit", comment: "Team settings edit button in navigation bar")
+    static let leave: String =
+      NSLocalizedString("Leave Team?", comment: "Leave Team?")
+    static let leaveBody: String =
+      NSLocalizedString("""
+This will remove your data linked to the team. You will not be able to participate in the challenge.
+""", comment: """
+This will remove your data linked to the team. You will not be able to participate in the challenge.
+""")
   }
 
   struct ConnectSource {

--- a/Steps4Impact/Networking/AKFCausesService.swift
+++ b/Steps4Impact/Networking/AKFCausesService.swift
@@ -133,6 +133,11 @@ class AKFCausesService: Service {
                    parameters: JSON(["team_id": team]), completion: completion)
   }
 
+  static func leaveTeam(fbid: String, completion: ServiceRequestCompletion? = nil) {
+    shared.request(.patch, endpoint: .participant(fbId: fbid),
+                   parameters: JSON(["team_id": nil]), completion: completion)
+  }
+
   static func performAPIHealthCheck(completion: ServiceRequestCompletion? = nil) {
     shared.request(endpoint: .healthcheck, completion: completion)
   }

--- a/Steps4Impact/Settings/SettingsViewController.swift
+++ b/Steps4Impact/Settings/SettingsViewController.swift
@@ -53,8 +53,15 @@ class SettingsViewController: TableViewController {
     case .viewTeam:
       navigationController?.pushViewController(TeamSettingsViewController(), animated: true)
     case .leaveTeam:
-      // TODO(compnerd) handle this
-      break
+      let alert: AlertViewController = AlertViewController()
+      alert.title = Strings.TeamSettings.leave
+      alert.body = Strings.TeamSettings.leaveBody
+      alert.add(AlertAction(title: "Cancel", style: .secondary))
+      alert.add(AlertAction(title: "Leave", style: .destructive) { [weak self] in
+        AKFCausesService.leaveTeam(fbid: Facebook.id)
+        self?.reload()
+      })
+      AppController.shared.present(alert: alert, in: self, completion: nil)
     case .logout:
       logout()
     case .deleteAccount:


### PR DESCRIPTION
This connects the leave team button and acts upon it.  It seems that
there is some problem with actually leaving the team on the back-end,
which prevents this from currently functioning.