### PR TITLE
Settings: disconnect delete team button

### DIFF
--- a/Steps4Impact/Settings/TeamSettingsDataSource.swift
+++ b/Steps4Impact/Settings/TeamSettingsDataSource.swift
@@ -31,6 +31,7 @@ import Foundation
 
 enum TeamSettingsContext: Context {
   case invite
+  case delete
 }
 
 class TeamSettingsDataSource: TableViewDataSource {
@@ -116,7 +117,7 @@ class TeamSettingsDataSource: TableViewDataSource {
       SettingsActionCellContext(
         title: "Delete Team",
         buttonStyle: .destructive,
-        context: nil)
+        context: TeamSettingsContext.delete)
     ]]
   }
 }

--- a/Steps4Impact/Settings/TeamSettingsViewController.swift
+++ b/Steps4Impact/Settings/TeamSettingsViewController.swift
@@ -57,9 +57,16 @@ class TeamSettingsViewController: TableViewController {
 
 extension TeamSettingsViewController: SettingsActionCellDelegate {
   func settingsActionCellTapped(context: Context?, button: UIButton) {
-    AppController.shared.shareTapped(
-      viewController: self,
-      shareButton: button,
-      string: Strings.Share.item)
+    guard let context = context as? TeamSettingsContext else { return }
+    switch context {
+    case .invite:
+      AppController.shared.shareTapped(
+          viewController: self,
+          shareButton: button,
+          string: Strings.Share.item)
+    case .delete:
+      break
+    }
+
   }
 }


### PR DESCRIPTION
Associate context with the button to differentiate the tapped button.