### PR TITLE
wire up some notifications instead of delegates

### DIFF
--- a/Steps4Impact/Challenge/Challenge.swift
+++ b/Steps4Impact/Challenge/Challenge.swift
@@ -29,6 +29,7 @@
 
 import UIKit
 import Foundation
+import NotificationCenter
 
 class ChallengeViewController: TableViewController {
   override func commonInit() {
@@ -36,6 +37,15 @@ class ChallengeViewController: TableViewController {
 
     title = Strings.Challenge.title
     dataSource = ChallengeDataSource()
+
+    _ = NotificationCenter.default.addObserver(forName: .teamChanged,
+                                               object: nil, queue: nil) { [weak self](_) in
+      self?.reload()
+    }
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 
   override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -51,27 +61,13 @@ class ChallengeViewController: TableViewController {
 
 extension ChallengeViewController: TeamNeededCellDelegate {
   func teamNeededCellPrimaryTapped() {
-    let createTeamVC = CreateTeamViewController()
-    createTeamVC.delegate = self
-    present(NavigationController(rootVC: createTeamVC), animated: true, completion: nil)
+    present(NavigationController(rootVC: CreateTeamViewController()),
+            animated: true, completion: nil)
   }
 
   func teamNeededCellSecondaryTapped() {
-    let joinVC = JoinTeamViewController()
-    joinVC.delegate = self
-    present(NavigationController(rootVC: joinVC), animated: true, completion: nil)
-  }
-}
-
-extension ChallengeViewController: JoinTeamViewControllerDelegate {
-  func joinTeamSuccess() {
-    reload()
-  }
-}
-
-extension ChallengeViewController: CreateTeamViewControllerDelegate {
-  func createTeamSuccess() {
-    reload()
+    present(NavigationController(rootVC: JoinTeamViewController()),
+            animated: true, completion: nil)
   }
 }
 

--- a/Steps4Impact/Challenge/CreateTeam.swift
+++ b/Steps4Impact/Challenge/CreateTeam.swift
@@ -28,10 +28,7 @@
  **/
 
 import UIKit
-
-protocol CreateTeamViewControllerDelegate: class {
-  func createTeamSuccess()
-}
+import NotificationCenter
 
 class CreateTeamViewController: ViewController {
   private let label = UILabel(typography: .title)
@@ -39,8 +36,6 @@ class CreateTeamViewController: ViewController {
   private let seperatorView = UIView()
   private let activityView = UIActivityIndicatorView(style: .gray)
   private var teamName: String = ""
-
-  weak var delegate: CreateTeamViewControllerDelegate?
 
   private var event: Event?
 
@@ -136,7 +131,7 @@ class CreateTeamViewController: ViewController {
             switch result {
             case .success:
               self.navigationController?.setViewControllers([CreateTeamSuccessViewController(for: self.event)], animated: true)
-              self.delegate?.createTeamSuccess()
+              NotificationCenter.default.post(name: .teamChanged, object: nil)
             case .failed:
               // If creating a team is successful but joining fails - delete it.
               AKFCausesService.deleteTeam(team: teamID)

--- a/Steps4Impact/Challenge/JoinTeam.swift
+++ b/Steps4Impact/Challenge/JoinTeam.swift
@@ -28,14 +28,10 @@
  **/
 
 import UIKit
-
-protocol JoinTeamViewControllerDelegate: class {
-  func joinTeamSuccess()
-}
+import NotificationCenter
 
 class JoinTeamViewController: TableViewController {
   var selectedId: Int?
-  weak var delegate: JoinTeamViewControllerDelegate?
 
   override func commonInit() {
     super.commonInit()
@@ -80,7 +76,6 @@ class JoinTeamViewController: TableViewController {
         if success {
           // Not pushing the success view controller because we don't want the user to be able to go back in the stack
           self.navigationController?.setViewControllers([JoinTeamSuccessViewController()], animated: true)
-          self.delegate?.joinTeamSuccess()
         } else {
           AppController.shared.present(alert: alert, in: self, completion: nil)
         }
@@ -202,6 +197,9 @@ class JoinTeamDataSource: TableViewDataSource {
   func joinTeam(team: Int, _ completion: @escaping (Bool) -> Void) {
     AKFCausesService.joinTeam(fbid: Facebook.id, team: team) { (result) in
       completion(result.isSuccess)
+      if result.isSuccess {
+        NotificationCenter.default.post(name: .teamChanged, object: nil)
+      }
     }
   }
 }

--- a/Steps4Impact/DashboardV2/DashboardViewController.swift
+++ b/Steps4Impact/DashboardV2/DashboardViewController.swift
@@ -28,6 +28,14 @@
  **/
 
 import UIKit
+import NotificationCenter
+
+extension NSNotification.Name {
+  static let teamChanged: NSNotification.Name =
+    NSNotification.Name(rawValue: "steps4impact.team-changed")
+  static let eventChanged: NSNotification.Name =
+    NSNotification.Name(rawValue: "steps4impact.event-changed")
+}
 
 class DashboardViewController: TableViewController {
   override func commonInit() {
@@ -40,6 +48,20 @@ class DashboardViewController: TableViewController {
       style: .plain,
       target: self,
       action: #selector(settingsButtonTapped))
+
+    // setup event handlers
+    _ = NotificationCenter.default.addObserver(forName: .teamChanged,
+                                               object: nil, queue: nil) { [weak self] (_) in
+      self?.reload()
+    }
+    _ = NotificationCenter.default.addObserver(forName: .eventChanged,
+                                               object: nil, queue: nil) { [weak self] (_) in
+      self?.reload()
+    }
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 
   override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/Steps4Impact/Login/LoginViewController.swift
+++ b/Steps4Impact/Login/LoginViewController.swift
@@ -31,6 +31,7 @@ import SnapKit
 import FacebookLogin
 import FacebookCore
 import SafariServices
+import NotificationCenter
 
 class LoginViewController: UIViewController {
   let imgLogo: UIImageView = UIImageView(image: Assets.logo.image)
@@ -119,13 +120,7 @@ extension LoginViewController: LoginButtonDelegate {
       }
       group.wait()
 
-      // NOTE(compnerd) this forces the reload since the event information
-      // needs to be populated and may not have been present when the view was
-      // loaded.  Unfortunately, we do not have a good way to get to the actual
-      // controller, so hardcode the expected path.
-      onMain {
-        (AppController.shared.navigation.viewControllers?.first as? TableViewController)?.reload()
-      }
+      NotificationCenter.default.post(name: .eventChanged, object: nil)
     }
 
     AppController.shared.login()

--- a/Steps4Impact/Settings/SettingsViewController.swift
+++ b/Steps4Impact/Settings/SettingsViewController.swift
@@ -29,6 +29,7 @@
 
 import UIKit
 import FacebookLogin
+import NotificationCenter
 
 class SettingsViewController: TableViewController {
   override func commonInit() {
@@ -36,6 +37,15 @@ class SettingsViewController: TableViewController {
 
     title = Strings.Settings.title
     dataSource = SettingsDataSource()
+
+    _ = NotificationCenter.default.addObserver(forName: .teamChanged,
+                                               object: nil, queue: nil) { [weak self] (_) in
+      self?.reload()
+    }
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 
   override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/Steps4Impact/Settings/TeamSettingsViewController.swift
+++ b/Steps4Impact/Settings/TeamSettingsViewController.swift
@@ -28,6 +28,7 @@
  **/
 
 import UIKit
+import NotificationCenter
 
 class TeamSettingsViewController: TableViewController {
   override func commonInit() {
@@ -40,6 +41,15 @@ class TeamSettingsViewController: TableViewController {
       style: .plain,
       target: self,
       action: #selector(editTapped))
+
+    _ = NotificationCenter.default.addObserver(forName: .teamChanged,
+                                               object: nil, queue: nil) { [weak self] (_) in
+      self?.reload()
+    }
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 
   override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -78,7 +88,7 @@ extension TeamSettingsViewController: SettingsActionCellDelegate {
             onMain {
               alert.dismiss(animated: true, completion: nil)
               self?.navigationController?.popViewController(animated: true)
-              // TODO(compnerd) refresh the dashboard, settings, and challenge views
+              NotificationCenter.default.post(name: .teamChanged, object: nil)
             }
           }
         })


### PR DESCRIPTION
Setup a team-changed and event-changed notification to refresh all the
various UIs appropriately.