### PR TITLE
event: alter default commitment

### DIFF
--- a/Steps4Impact/Login/LoginViewController.swift
+++ b/Steps4Impact/Login/LoginViewController.swift
@@ -106,10 +106,9 @@ extension LoginViewController: LoginButtonDelegate {
           group.enter()
           AKFCausesService.getEvents { (result) in
             if let events: [Event] = result.response?.arrayValue?.compactMap({ (json) in Event(json: json) }),
-                let eid = events.first?.id {
+               let eid = events.first?.id, let defaultSteps = events.first?.defaultStepCount {
               group.enter()
-              // TODO(compnerd) do not hard code the distance here (we should push this to the backend to provide)
-              AKFCausesService.joinEvent(fbid: Facebook.id, eventID: eid, miles: 500) { (_) in
+              AKFCausesService.joinEvent(fbid: Facebook.id, eventID: eid, steps: defaultSteps) { (_) in
                 group.leave()
               }
             }

--- a/Steps4Impact/Models/Event.swift
+++ b/Steps4Impact/Models/Event.swift
@@ -43,6 +43,7 @@ struct Event {
   let challengePhase: DateRange
   let teamFormationPhase: DateRange
   let teamLimit: Int
+  let defaultStepCount: Int
   let cause: Cause?
 
   init?(json: JSON?) {
@@ -73,6 +74,12 @@ struct Event {
         DateRange(start: formatter.date(from: teamBuildingStart) ?? Date(),
                   end: formatter.date(from: teamBuildingEnd) ?? Date())
     self.teamLimit = teamLimit
+
+    if let defaultSteps = json["default_steps"]?.intValue {
+      self.defaultStepCount = defaultSteps
+    } else {
+      self.defaultStepCount = 10000 * challengePhase.start.daysUntil(challengePhase.end)
+    }
 
     if let cause = json["cause"] {
       self.cause = Cause(json: cause)

--- a/Steps4Impact/Models/Participant.swift
+++ b/Steps4Impact/Models/Participant.swift
@@ -65,7 +65,7 @@ struct Participant {
           commitment = event["participant_event"]?["commitment"]?.intValue
         }
       }
-      self.currentEventCommitment = commitment
+      self.currentEventCommitment = commitment! / 2000 // steps to miles
     } else {
       self.events = []
       self.currentEventCommitment = nil

--- a/Steps4Impact/Networking/AKFCausesService.swift
+++ b/Steps4Impact/Networking/AKFCausesService.swift
@@ -184,10 +184,10 @@ class AKFCausesService: Service {
     shared.request(endpoint: .sources, completion: completion)
   }
 
-  static func joinEvent(fbid: String, eventID: Int, miles: Int,
+  static func joinEvent(fbid: String, eventID: Int, steps: Int,
                         commpletion: ServiceRequestCompletion? = nil) {
     shared.request(.post, endpoint: .commitments,
-                   parameters: JSON(["fbid": fbid, "event_id": eventID, "commitment": miles]),
+                   parameters: JSON(["fbid": fbid, "event_id": eventID, "commitment": steps]),
                    completion: commpletion)
   }
 


### PR DESCRIPTION
The backend is tracking steps, not miles.  Adjust the default steps to
pull from the backend.  Default the value to 10k Steps per diem until
the default value is pushed down.

Convert the retrieved commitment from the server to miles before
presenting.