### PR TITLE
Settings: load commitment from server

### DIFF
--- a/Steps4Impact/Settings/SettingsDataSource.swift
+++ b/Steps4Impact/Settings/SettingsDataSource.swift
@@ -61,7 +61,7 @@ class SettingsDataSource: TableViewDataSource {
         if let participant = Participant(json: result.response) {
           self?.isOnTeam = participant.team != nil
           self?.isTeamLead = participant.team?.creator == participant.fbid
-          self?.commitment = participant.currentEventCommitment!
+          self?.commitment = participant.currentEventCommitment ?? 0
         }
         group.leave()
       }


### PR DESCRIPTION
Actually render the commitment recorded rather than the placeholder.
Although the user cannot modify the value yet, this allows us to render
the value properly.  Since the default commitment is now corrected, we
should be able to render this properly.