### PR TITLE
commitment: wire up commitment editing from settings

### DIFF
--- a/Steps4Impact/Challenge/Challenge.swift
+++ b/Steps4Impact/Challenge/Challenge.swift
@@ -44,7 +44,11 @@ class ChallengeViewController: TableViewController {
       action: #selector(settingsButtonTapped))
 
     _ = NotificationCenter.default.addObserver(forName: .teamChanged,
-                                               object: nil, queue: nil) { [weak self](_) in
+                                               object: nil, queue: nil) { [weak self] (_) in
+      self?.reload()
+    }
+    _ = NotificationCenter.default.addObserver(forName: .commitmentChanged,
+                                               object: nil, queue: nil) { [weak self] (_) in
       self?.reload()
     }
   }

--- a/Steps4Impact/DashboardV2/DashboardViewController.swift
+++ b/Steps4Impact/DashboardV2/DashboardViewController.swift
@@ -35,6 +35,8 @@ extension NSNotification.Name {
     NSNotification.Name(rawValue: "steps4impact.team-changed")
   static let eventChanged: NSNotification.Name =
     NSNotification.Name(rawValue: "steps4impact.event-changed")
+  static let commitmentChanged: NSNotification.Name =
+    NSNotification.Name(rawValue: "steps4impact.commitment-changed")
 }
 
 class DashboardViewController: TableViewController {

--- a/Steps4Impact/Models/Participant.swift
+++ b/Steps4Impact/Models/Participant.swift
@@ -36,7 +36,9 @@ struct Participant {
   let events: [Event]
   let preferredCause: Cause?
   let records: [Record]
+
   let currentEventCommitment: Int?
+  let currentEventCommitmentId: Int?
 
   init?(json: JSON?) {
     guard let json = json else { return nil }
@@ -62,19 +64,24 @@ struct Participant {
       self.events = events.compactMap({ (json) in Event(json: json) })
 
       var commitment: Int?
+      var commitmentId: Int?
       for event in events {
         if formatter.date(from: event["end_date"]?.stringValue ?? "")?.timeIntervalSinceNow.sign == .plus {
           commitment = event["participant_event"]?["commitment"]?.intValue
+          commitmentId = event["participant_event"]?["id"]?.intValue
         }
       }
-      if let commitment = commitment {
+      if let commitment = commitment, let commitmentId = commitmentId {
         self.currentEventCommitment = commitment / 2000 // steps to miles
+        self.currentEventCommitmentId = commitmentId
       } else {
         self.currentEventCommitment = nil
+        self.currentEventCommitmentId = nil
       }
     } else {
       self.events = []
       self.currentEventCommitment = nil
+      self.currentEventCommitmentId = nil
     }
     if let cause = json["cause"] {
       self.preferredCause = Cause(json: cause)

--- a/Steps4Impact/Networking/AKFCausesService.swift
+++ b/Steps4Impact/Networking/AKFCausesService.swift
@@ -41,8 +41,8 @@ enum AKFCausesEndPoint {
   case records
   case source(sourceId: Int)
   case sources
-  case commitment(fbid: String)
-  case commitments
+  case commitment
+  case commitments(id: Int)
 }
 
 extension AKFCausesEndPoint {
@@ -70,10 +70,10 @@ extension AKFCausesEndPoint {
       return "/sources/\(sourceId)"
     case .sources:
       return "/sources"
-    case .commitment(let fbid):
-      return "/commitments/participant/\(fbid)"
-    case .commitments:
+    case .commitment:
       return "/commitments"
+    case .commitments(let id):
+      return "/commitments/\(id)"
     }
   }
 }
@@ -199,15 +199,15 @@ class AKFCausesService: Service {
 
   static func joinEvent(fbid: String, eventID: Int, steps: Int,
                         commpletion: ServiceRequestCompletion? = nil) {
-    shared.request(.post, endpoint: .commitments,
+    shared.request(.post, endpoint: .commitment,
                    parameters: JSON(["fbid": fbid, "event_id": eventID, "commitment": steps]),
                    completion: commpletion)
   }
 
-  static func setCommitment(for fbid: String, andEvent event: Int, toSteps steps: Int,
+  static func setCommitment(_ commitment: Int, toSteps steps: Int,
                             completion: ServiceRequestCompletion? = nil) {
-    shared.request(.patch, endpoint: .commitments,
-                   parameters: JSON(["fbid": fbid, "event_id": event, "commitment": steps]),
+    shared.request(.patch, endpoint: .commitments(id: commitment),
+                   parameters: JSON(["commitment": steps]),
                    completion: completion)
   }
 }


### PR DESCRIPTION
Add support to update commitments from settings.  Refresh the challenge
view on an update.  Resolves #277!