### PR TITLE
Disable AKF Profile

### DIFF
--- a/Steps4Impact/App/AppController.swift
+++ b/Steps4Impact/App/AppController.swift
@@ -122,9 +122,10 @@ class AppController {
   }
 
   func login() {
-    if !UserInfo.AKFProfileCreated {
-      transition(to: .akf)
-    } else if !UserInfo.onboardingComplete {
+//    if !UserInfo.AKFProfileCreated {
+//      transition(to: .akf)
+//    }
+    if !UserInfo.onboardingComplete {
       transition(to: .onboarding)
     } else {
       transition(to: .navigation)

--- a/Steps4Impact/App/AppController.swift
+++ b/Steps4Impact/App/AppController.swift
@@ -122,9 +122,7 @@ class AppController {
   }
 
   func login() {
-//    if !UserInfo.AKFProfileCreated {
-//      transition(to: .akf)
-//    }
+    // TODO: Add check to go to akf sign up form 
     if !UserInfo.onboardingComplete {
       transition(to: .onboarding)
     } else {


### PR DESCRIPTION
```Guideline 3.2.2 - Business - Other Business Model Issues - Unacceptable


In addition, we noticed that your app includes the ability to collect charitable donations within the app, which is not appropriate for the App Store.

Next Steps

While donations may not be taken within an app, you may provide a link to your website that launches Safari for users to make a donation. You may also add a link to send an SMS to make the donation.

We understand that directing your user outside of your app may not be the experience you prefer to offer your users. However, it is a common experience in a variety of iOS apps. And in the case of collecting donations for charities - regardless of whether the donations are in cash or another form - it is also the required user experience.
```


![attachment-2311645521424871287Screenshot-1026-121431](https://user-images.githubusercontent.com/1434903/67827914-d619ac80-faa7-11e9-9f74-7a5575c0d1f3.png)
![attachment-6267542397542092209Screenshot-1026-121525](https://user-images.githubusercontent.com/1434903/67827915-d619ac80-faa7-11e9-87ae-c83fab607a6a.png)

