### PR TITLE
Issue#384 Big Heading

### DIFF
--- a/Steps4Impact/Journey/JourneyViewController.swift
+++ b/Steps4Impact/Journey/JourneyViewController.swift
@@ -25,6 +25,7 @@ class JourneyViewController: TableViewController {
     label.textColor = Style.Colors.FoundationGreen
     return label
   }()
+  var viewDisplayed = false
 
   override func commonInit() {
     super.commonInit()
@@ -66,6 +67,11 @@ class JourneyViewController: TableViewController {
       self?.tableView.reloadOnMain()
     }
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    viewDisplayed = true
+  }
 }
 
 extension JourneyViewController {
@@ -75,6 +81,12 @@ extension JourneyViewController {
     }
     if let cell = cell as? CurrentMilestoneCell {
       cell.delegate = self
+    }
+  }
+  
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    if viewDisplayed && scrollView.contentOffset.y + scrollView.contentInset.top < 0 {
+      topProgressView.frame.origin.y = Style.Size.s64 + abs(scrollView.contentOffset.y)
     }
   }
 }

--- a/Steps4Impact/Journey/JourneyViewController.swift
+++ b/Steps4Impact/Journey/JourneyViewController.swift
@@ -14,6 +14,7 @@ class JourneyViewController: TableViewController {
     let view = UIView()
     view.backgroundColor = .white
     view.alpha = 1
+    view.layer.applySketchShadow(color: Style.Colors.FoundationGrey, alpha: 0.2, x: 0, y: 2, blur: 3, spread: 0)
     return view
   }()
 

--- a/Steps4Impact/Journey/JourneyViewController.swift
+++ b/Steps4Impact/Journey/JourneyViewController.swift
@@ -14,7 +14,6 @@ class JourneyViewController: TableViewController {
     let view = UIView()
     view.backgroundColor = .white
     view.alpha = 1
-    view.layer.applySketchShadow(color: Style.Colors.FoundationGrey, alpha: 1, x: 0, y: -5, blur: 8, spread: 0)
     return view
   }()
 
@@ -33,7 +32,6 @@ class JourneyViewController: TableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     title = Strings.Journey.title
-    navigationController?.navigationBar.prefersLargeTitles = false
     view.backgroundColor = .white
     tableView.backgroundColor = .white
     tableView.contentInset = UIEdgeInsets(top: Style.Size.s64 + Style.Padding.p12, left: 0, bottom: 0, right: 0)
@@ -89,4 +87,3 @@ extension JourneyViewController: MilestoneNameButtonDelegate {
     }
   }
 }
-


### PR DESCRIPTION
Removed preferesLargeTitles = false, as it disturbs large title in navigation flow. 
Programmatically scrolling topProgressView down when PullToRefresh is used as topProgressView doesn't scroll automatically and navigation title overlaps it

PS: I tried bunch of ways to fix it but didn't work, let me know if there is any better solution that this