### PR TITLE
Dashboard Fixes

### DIFF
--- a/Steps4Impact/App/Strings.swift
+++ b/Steps4Impact/App/Strings.swift
@@ -86,6 +86,11 @@ struct Strings {
       static let unavailable = NSLocalizedString("Dashboard.FundraisingProgress.unavailable", comment: "")
       static let invite = NSLocalizedString("Dashboard.FundraisingProgress.invite", comment: "")
     }
+    
+    struct NoCurrentEvent { // swiftlint:disable:this nesting
+      static let name = NSLocalizedString("Dashboard.NoCurrentEvent.name", comment: "")
+      static let timeline = NSLocalizedString("Dashboard.NoCurrentEvent.timeline", comment: "")
+    }
   }
 
   struct Journey {

--- a/Steps4Impact/DashboardV2/DashboardDataSource.swift
+++ b/Steps4Impact/DashboardV2/DashboardDataSource.swift
@@ -53,6 +53,10 @@ class DashboardDataSource: TableViewDataSource {
   private var healthKitDataProvider = HealthKitDataProvider()
   private var fitBitDataProvider = FitbitDataProvider()
 
+  // Constants
+  private let monthsInSeconds: Double = 60 * 60 * 24 * 30
+  private let defaultCommitment = 300 // in miles, comes out to 10,000 steps per day for 2 months
+  
   enum DashboardContext: Context {
     case inviteSupporters
   }
@@ -74,16 +78,15 @@ class DashboardDataSource: TableViewDataSource {
         self.eventTimelineString = DataFormatters
           .formatDateRange(value: (start: event.challengePhase.start, end: event.challengePhase.end))
         self.eventLengthInDays = event.lengthInDays
-        self.commitment = event.commitment?.miles ?? 300
+        self.commitment = event.commitment?.miles ?? self.defaultCommitment
       } else {
         self.eventName = "No Current Event"
-        let monthsInSeconds: Double = 60 * 60 * 24 * 30
         self.eventTimeline = DateInterval(
-          start: Date(timeIntervalSinceNow: -monthsInSeconds),
-          end: Date(timeIntervalSinceNow: monthsInSeconds))
+          start: Date(timeIntervalSinceNow: -self.monthsInSeconds),
+          end: Date(timeIntervalSinceNow: self.monthsInSeconds))
         self.eventTimelineString = "Last 2 Months"
         self.eventLengthInDays = self.eventTimeline.start.daysUntil(self.eventTimeline.end)
-        self.commitment = 300
+        self.commitment = self.defaultCommitment
       }
       self.configure()
       self.completion?()

--- a/Steps4Impact/DashboardV2/DashboardDataSource.swift
+++ b/Steps4Impact/DashboardV2/DashboardDataSource.swift
@@ -80,11 +80,11 @@ class DashboardDataSource: TableViewDataSource {
         self.eventLengthInDays = event.lengthInDays
         self.commitment = event.commitment?.miles ?? self.defaultCommitment
       } else {
-        self.eventName = "No Current Event"
+        self.eventName = Strings.Dashboard.NoCurrentEvent.name
         self.eventTimeline = DateInterval(
           start: Date(timeIntervalSinceNow: -self.monthsInSeconds),
           end: Date(timeIntervalSinceNow: self.monthsInSeconds))
-        self.eventTimelineString = "Last 2 Months"
+        self.eventTimelineString = Strings.Dashboard.NoCurrentEvent.timeline
         self.eventLengthInDays = self.eventTimeline.start.daysUntil(self.eventTimeline.end)
         self.commitment = self.defaultCommitment
       }

--- a/Steps4Impact/DashboardV2/DashboardDataSource.swift
+++ b/Steps4Impact/DashboardV2/DashboardDataSource.swift
@@ -74,8 +74,17 @@ class DashboardDataSource: TableViewDataSource {
         self.eventTimelineString = DataFormatters
           .formatDateRange(value: (start: event.challengePhase.start, end: event.challengePhase.end))
         self.eventLengthInDays = event.lengthInDays
+        self.commitment = event.commitment?.miles ?? 300
+      } else {
+        self.eventName = "No Current Event"
+        let monthsInSeconds: Double = 60 * 60 * 24 * 30
+        self.eventTimeline = DateInterval(
+          start: Date(timeIntervalSinceNow: -monthsInSeconds),
+          end: Date(timeIntervalSinceNow: monthsInSeconds))
+        self.eventTimelineString = "Last 2 Months"
+        self.eventLengthInDays = self.eventTimeline.start.daysUntil(self.eventTimeline.end)
+        self.commitment = 300
       }
-      self.commitment = participant?.currentEvent?.commitment?.miles ?? 0
       self.configure()
       self.completion?()
       self.getPedometerData()

--- a/Steps4Impact/DashboardV2/DashboardViewController.swift
+++ b/Steps4Impact/DashboardV2/DashboardViewController.swift
@@ -61,6 +61,11 @@ class DashboardViewController: TableViewController {
       self?.reload()
     }
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    reload()
+  }
 
   deinit {
     NotificationCenter.default.removeObserver(self)

--- a/Steps4Impact/Supporting Files/en.lproj/Localizable.strings
+++ b/Steps4Impact/Supporting Files/en.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Dashboard.FundraisingProgress.title" = "Fundraising Progress";
 "Dashboard.FundraisingProgress.unavailable" = "No data available. You will be able to see your progress once the challenge has started.";
 "Dashboard.FundraisingProgress.invite" = "Invite supporters to pledge";
+"Dashboard.NoCurrentEvent.name" = "No Current Event";
+"Dashboard.NoCurrentEvent.timeline" = "Last 2 Months";
 
 // Journey
 "Journey.title" = "Journey";

--- a/Steps4Impact/Supporting Files/hi.lproj/Localizable.strings
+++ b/Steps4Impact/Supporting Files/hi.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "Dashboard.FundraisingProgress.title" = "Fundraising Progress";
 "Dashboard.FundraisingProgress.unavailable" = "No data available. You will be able to see your progress once the challenge has started.";
 "Dashboard.FundraisingProgress.invite" = "Invite supporters to pledge";
+"Dashboard.NoCurrentEvent.name" = "No Current Event";
+"Dashboard.NoCurrentEvent.timeline" = "Last 2 Months";
 
 // Journey
 "Journey.title" = "Journey";


### PR DESCRIPTION
- Set last 2 months of data to show up if no current event for participant and 300 miles for a default commitment. 

![Screenshot 2020-08-15 at 19 00 40](https://user-images.githubusercontent.com/1434903/90323670-0d1f5880-df2a-11ea-82cf-c71e4baaa73b.jpeg)
