### PR TITLE
Issue #401

### DIFF
--- a/Steps4Impact.xcodeproj/project.pbxproj
+++ b/Steps4Impact.xcodeproj/project.pbxproj
@@ -1596,7 +1596,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Steps4Impact/Supporting Files/Steps4Impact.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 277;
+				CURRENT_PROJECT_VERSION = 278;
 				DEVELOPMENT_TEAM = 6SQ8F32998;
 				INFOPLIST_FILE = "Steps4Impact/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1620,7 +1620,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Steps4Impact/Supporting Files/Steps4Impact.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 277;
+				CURRENT_PROJECT_VERSION = 278;
 				DEVELOPMENT_TEAM = 6SQ8F32998;
 				INFOPLIST_FILE = "Steps4Impact/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Steps4Impact/App/Strings.swift
+++ b/Steps4Impact/App/Strings.swift
@@ -209,4 +209,16 @@ struct Strings {
       return String(format: NSLocalizedString("Share.item", comment: ""), teamName)
     }
   }
+  
+  struct CommitmentAlert {
+    static let title = NSLocalizedString("CommitmentAlert.title", comment: "")
+    struct Failure {
+      static let title = NSLocalizedString("CommitmentAlert.Failure.title", comment: "")
+      static let body = NSLocalizedString("CommitmentAlert.Failure.body", comment: "")
+    }
+    struct Fallback {
+      static let title = NSLocalizedString("CommitmentAlert.Fallback.title", comment: "")
+      static let body = NSLocalizedString("CommitmentAlert.Fallback.body", comment: "")
+    }
+  }
 }

--- a/Steps4Impact/Challenge/Challenge.swift
+++ b/Steps4Impact/Challenge/Challenge.swift
@@ -122,32 +122,41 @@ extension ChallengeViewController: ChallengeTeamProgressCellDelegate {
   func challengeTeamProgressEditTapped() {
     AKFCausesService.getParticipant(fbid: User.id) { (result) in
       guard let participant = Participant(json: result.response) else { return }
-
-      let alert = TextAlertViewController()
-      alert.title = "Personal mile commitment"
-      alert.value = "\(participant.currentEvent?.commitment?.miles ?? 0)"
-      alert.suffix = "Miles"
-      alert.add(.init(title: "Save", style: .primary, shouldDismiss: false) {
-        if let cid = participant.currentEvent?.commitment?.id {
-          AKFCausesService.setCommitment(cid, toSteps: (Int(alert.value ?? "0") ?? 0) * 2000) { (result) in
-            alert.dismiss(animated: true) {
-              if result.isSuccess {
-                NotificationCenter.default.post(name: .commitmentChanged, object: nil)
-              } else {
-                let alert: AlertViewController = AlertViewController()
-                alert.title = "Update Failed"
-                alert.body = "Could not update commitment.  Please try again later."
-                alert.add(.okay())
-                onMain {
-                  AppController.shared.present(alert: alert, in: self, completion: nil)
+      if let _ = participant.currentEvent {
+        let alert = TextAlertViewController()
+        alert.title = "Personal mile commitment"
+        alert.value = "\(participant.currentEvent?.commitment?.miles ?? 0)"
+        alert.suffix = "Miles"
+        alert.add(.init(title: "Save", style: .primary, shouldDismiss: false) {
+          if let cid = participant.currentEvent?.commitment?.id {
+            AKFCausesService.setCommitment(cid, toSteps: (Int(alert.value ?? "0") ?? 0) * 2000) { (result) in
+              alert.dismiss(animated: true) {
+                if result.isSuccess {
+                  NotificationCenter.default.post(name: .commitmentChanged, object: nil)
+                } else {
+                  let alert: AlertViewController = AlertViewController()
+                  alert.title = "Update Failed"
+                  alert.body = "Could not update commitment.  Please try again later."
+                  alert.add(.okay())
+                  onMain {
+                    AppController.shared.present(alert: alert, in: self, completion: nil)
+                  }
                 }
               }
             }
           }
-        }
-      })
-      alert.add(.cancel())
-      AppController.shared.present(alert: alert, in: self, completion: nil)
+        })
+        alert.add(.cancel())
+        AppController.shared.present(alert: alert, in: self, completion: nil)
+      } else {
+        let alert = AlertViewController()
+        alert.title = "No Event Available"
+        alert.body = "Can't update commitment when there is no event available"
+        alert.add(.okay({
+          alert.dismiss(animated: true, completion: nil)
+        }))
+        AppController.shared.present(alert: alert, in: self, completion: nil)
+      }
     }
   }
 }

--- a/Steps4Impact/Challenge/Challenge.swift
+++ b/Steps4Impact/Challenge/Challenge.swift
@@ -124,7 +124,7 @@ extension ChallengeViewController: ChallengeTeamProgressCellDelegate {
       guard let participant = Participant(json: result.response) else { return }
       if let _ = participant.currentEvent {
         let alert = TextAlertViewController()
-        alert.title = "Personal mile commitment"
+        alert.title = Strings.CommitmentAlert.title
         alert.value = "\(participant.currentEvent?.commitment?.miles ?? 0)"
         alert.suffix = "Miles"
         alert.add(.init(title: "Save", style: .primary, shouldDismiss: false) {
@@ -135,8 +135,8 @@ extension ChallengeViewController: ChallengeTeamProgressCellDelegate {
                   NotificationCenter.default.post(name: .commitmentChanged, object: nil)
                 } else {
                   let alert: AlertViewController = AlertViewController()
-                  alert.title = "Update Failed"
-                  alert.body = "Could not update commitment.  Please try again later."
+                  alert.title = Strings.CommitmentAlert.Failure.title
+                  alert.body = Strings.CommitmentAlert.Failure.body
                   alert.add(.okay())
                   onMain {
                     AppController.shared.present(alert: alert, in: self, completion: nil)
@@ -150,8 +150,8 @@ extension ChallengeViewController: ChallengeTeamProgressCellDelegate {
         AppController.shared.present(alert: alert, in: self, completion: nil)
       } else {
         let alert = AlertViewController()
-        alert.title = "No Event Available"
-        alert.body = "Can't update commitment when there is no event available"
+        alert.title = Strings.CommitmentAlert.Fallback.title
+        alert.body = Strings.CommitmentAlert.Fallback.body
         alert.add(.okay({
           alert.dismiss(animated: true, completion: nil)
         }))

--- a/Steps4Impact/Challenge/TeamBreakdown/Cells/TeamBreakdownMemberCell.swift
+++ b/Steps4Impact/Challenge/TeamBreakdown/Cells/TeamBreakdownMemberCell.swift
@@ -78,7 +78,7 @@ class TeamBreakdownMemberCell: ConfigurableTableViewCell, Contextable {
     contentView.addSubview(countLabel) {
       $0.leading.equalToSuperview().inset(Style.Padding.p32)
       $0.centerY.equalToSuperview()
-      $0.width.equalToSuperview().dividedBy(20)
+      $0.width.equalTo(24)
     }
 
     contentView.addSubview(profileImageView) {

--- a/Steps4Impact/Settings/SettingsViewController.swift
+++ b/Steps4Impact/Settings/SettingsViewController.swift
@@ -122,7 +122,7 @@ class SettingsViewController: TableViewController {
       guard let participant = Participant(json: result.response) else { return }
       if let _ = participant.currentEvent {
         let alert = TextAlertViewController()
-        alert.title = "Personal mile commitment"
+        alert.title = Strings.CommitmentAlert.title
         alert.value = "\(participant.currentEvent?.commitment?.miles ?? 0)"
         alert.suffix = "Miles"
         alert.add(.init(title: "Save", style: .primary, shouldDismiss: false) {
@@ -131,8 +131,8 @@ class SettingsViewController: TableViewController {
               alert.dismiss(animated: true) {
                 if !result.isSuccess {
                   let alert: AlertViewController = AlertViewController()
-                  alert.title = "Update Failed"
-                  alert.body = "Could not update commitment.  Please try again later."
+                  alert.title = Strings.CommitmentAlert.Failure.title
+                  alert.body = Strings.CommitmentAlert.Failure.body
                   alert.add(.okay())
                   onMain {
                     AppController.shared.present(alert: alert, in: self, completion: nil)
@@ -152,8 +152,8 @@ class SettingsViewController: TableViewController {
         AppController.shared.present(alert: alert, in: self, completion: nil)
       } else {
         let alert = AlertViewController()
-        alert.title = "No Event Available"
-        alert.body = "Can't update commitment when there is no event available"
+        alert.title = Strings.CommitmentAlert.Fallback.title
+        alert.body = Strings.CommitmentAlert.Fallback.body
         alert.add(.okay({
           alert.dismiss(animated: true, completion: nil)
         }))

--- a/Steps4Impact/Supporting Files/en.lproj/Localizable.strings
+++ b/Steps4Impact/Supporting Files/en.lproj/Localizable.strings
@@ -161,3 +161,10 @@
 
 // Share
 "Share.item" = "Hey! I created a team %@ for the AKF Walk Challenge on the new Aga Khan Foundation app, Steps4Impact, and I want you on my team!\nDownload the app here:\nhttp://rebrand.ly/steps4impact-iphone\nhttp://rebrand.ly/steps4impact-android";
+
+// Commitment
+"CommitmentAlert.title" = "Personal mile commitment";
+"CommitmentAlert.Failure.title" = "Update Failed";
+"CommitmentAlert.Failure.body" = "Could not update commitment.  Please try again later.";
+"CommitmentAlert.Fallback.title" = "No Event Available";
+"CommitmentAlert.Fallback.body" = "Can't update commitment when there is no event available";

--- a/Steps4Impact/Supporting Files/hi.lproj/Localizable.strings
+++ b/Steps4Impact/Supporting Files/hi.lproj/Localizable.strings
@@ -162,3 +162,9 @@
 // Share
 "Share.item" = "Hey! I created a team for the AKF Walk Challenge on the new Aga Khan Foundation app, Steps4Impact, and I want you on my team!\nDownload the app here:\nhttp://rebrand.ly/steps4impact-iphone\nhttp://rebrand.ly/steps4impact-android";
 
+// Commitment
+"CommitmentAlert.title" = "Personal mile commitment";
+"CommitmentAlert.Failure.title" = "Update Failed";
+"CommitmentAlert.Failure.body" = "Could not update commitment.  Please try again later.";
+"CommitmentAlert.Fallback.title" = "No Event Available";
+"CommitmentAlert.Fallback.body" = "Can't update commitment when there is no event available";   


### PR DESCRIPTION
1. Personal Commitment: 
- Added a check if current event is available  when trying to edit the commitment miles
- Added alert message when current event is not available

2. Team Breakdown:
- Count label on team breakdown page was over running the width, so increased the width.