### PR TITLE
App: attempt to remove RxCocoa

### DIFF
--- a/Steps4Impact/App/Cache.swift
+++ b/Steps4Impact/App/Cache.swift
@@ -29,7 +29,6 @@
 
 import Foundation
 import RxSwift
-import RxCocoa
 
 class Cache {
   static let shared = Cache()


### PR DESCRIPTION
`RxCocoa` has a dependency on `UIWebView` which is deprecated for security issues.  Attempt to remove the `RxCocoa` dependency, `RxSwift` should be sufficient for our needs.