### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 pool:
-  vmImage: 'macOS-10.14'
+  vmImage: 'macOS-latest'
 
 steps:
 - task: DownloadSecureFile@1


### PR DESCRIPTION
Update the Azure pipeline to use the macOS latest builder.  This will switch us from macOS Mojave to macOS Big Sur.  Though we could use macOS Monterey, this label uses the evergreen label for the macOS builder to avoid having to continually update.