### PR TITLE
Steps4Impact: update for syntactic changes to Swift

### DIFF
--- a/Steps4Impact/BadgesV2/Cells/BadgeCell.swift
+++ b/Steps4Impact/BadgesV2/Cells/BadgeCell.swift
@@ -20,7 +20,7 @@ struct Badge: CellContext {
   var badgeType: BadgeType = .unknown
 }
 
-protocol BadgeCellDelegate: class {
+protocol BadgeCellDelegate: AnyObject {
   func badgeCellTapped()
 }
 

--- a/Steps4Impact/Challenge/Cells/ChallengeTeamProgressCell.swift
+++ b/Steps4Impact/Challenge/Cells/ChallengeTeamProgressCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol ChallengeTeamProgressCellDelegate: class {
+protocol ChallengeTeamProgressCellDelegate: AnyObject {
   func challengeTeamProgressDisclosureTapped()
   func challengeTeamProgressEditTapped()
 }

--- a/Steps4Impact/Challenge/Cells/TeamNeededCell.swift
+++ b/Steps4Impact/Challenge/Cells/TeamNeededCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol TeamNeededCellDelegate: class {
+protocol TeamNeededCellDelegate: AnyObject {
   func teamNeededCellPrimaryTapped()
   func teamNeededCellSecondaryTapped()
 }

--- a/Steps4Impact/CommonUI/Cells/DisclosureCell.swift
+++ b/Steps4Impact/CommonUI/Cells/DisclosureCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol DisclosureCellDelegate: class {
+protocol DisclosureCellDelegate: AnyObject {
   func disclosureCellTapped(context: Context?)
 }
 

--- a/Steps4Impact/CommonUI/Cells/ImageButtonCell.swift
+++ b/Steps4Impact/CommonUI/Cells/ImageButtonCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol ImageButtonCellDelegate: class {
+protocol ImageButtonCellDelegate: AnyObject {
   func imageButtonCellTapped(context: Context?)
 }
 

--- a/Steps4Impact/CommonUI/Views/CellDisclosureView.swift
+++ b/Steps4Impact/CommonUI/Views/CellDisclosureView.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol CellDisclosureViewDelegate: class {
+protocol CellDisclosureViewDelegate: AnyObject {
   func cellDisclosureTapped()
 }
 

--- a/Steps4Impact/CommonUI/Views/CellImageButtonView.swift
+++ b/Steps4Impact/CommonUI/Views/CellImageButtonView.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol CellImageButtonViewDelegate: class {
+protocol CellImageButtonViewDelegate: AnyObject {
   func cellImageButtonViewTapped()
 }
 

--- a/Steps4Impact/CommonUI/Views/RadioButton.swift
+++ b/Steps4Impact/CommonUI/Views/RadioButton.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol RadioButtonDelegate: class {
+protocol RadioButtonDelegate: AnyObject {
   func radioButtonTapped(radioButton: RadioButton)
 }
 

--- a/Steps4Impact/CommonUI/Views/SelectionButton.swift
+++ b/Steps4Impact/CommonUI/Views/SelectionButton.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol SelectionButtonDataSource: class {
+protocol SelectionButtonDataSource: AnyObject {
   var items: [String] { get }
   var selection: Int? { get set }
 }
@@ -102,7 +102,7 @@ extension SelectionButtonPopoverViewController: UIPopoverPresentationControllerD
   }
 }
 
-protocol SelectionButtonDelegate: class {
+protocol SelectionButtonDelegate: AnyObject {
   func present(_ viewControllerToPresent: UIViewController,
                animated flag: Bool, completion: (() -> Swift.Void)?)
 }

--- a/Steps4Impact/DashboardV2/Cells/ConnectedActivityCardCell.swift
+++ b/Steps4Impact/DashboardV2/Cells/ConnectedActivityCardCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol ConnectedActivityCellDelegate: class {
+protocol ConnectedActivityCellDelegate: AnyObject {
 }
 
 struct ConnectedActivityCellContext: CellContext {

--- a/Steps4Impact/DashboardV2/Cells/EmptyActivityCardCell.swift
+++ b/Steps4Impact/DashboardV2/Cells/EmptyActivityCardCell.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol EmptyActivityCellDelegate: class {
+protocol EmptyActivityCellDelegate: AnyObject {
   func emptyActivityCellConnectTapped()
 }
 

--- a/Steps4Impact/DashboardV2/Cells/ProfileCardCell.swift
+++ b/Steps4Impact/DashboardV2/Cells/ProfileCardCell.swift
@@ -31,7 +31,7 @@ import UIKit
 import SnapKit
 import SDWebImage
 
-protocol ProfileCardCellDelegate: class {
+protocol ProfileCardCellDelegate: AnyObject {
   func profileDisclosureTapped()
 }
 

--- a/Steps4Impact/DashboardV2/Views/ActivityDateView.swift
+++ b/Steps4Impact/DashboardV2/Views/ActivityDateView.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol ActivityDateViewDelegate: class {
+protocol ActivityDateViewDelegate: AnyObject {
   func activityDateViewLeftTapped()
   func activityDateViewRightTapped()
 }

--- a/Steps4Impact/DashboardV2/Views/ActivityTimeView.swift
+++ b/Steps4Impact/DashboardV2/Views/ActivityTimeView.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol ActivityTimeViewDelegate: class {
+protocol ActivityTimeViewDelegate: AnyObject {
   func activityTimeViewTapped(time: ActivityTime)
 }
 

--- a/Steps4Impact/DashboardV2/Views/ActivityUnitView.swift
+++ b/Steps4Impact/DashboardV2/Views/ActivityUnitView.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol ActivityUnitViewDelegate: class {
+protocol ActivityUnitViewDelegate: AnyObject {
   func activityUnitViewTapped(unit: ActivityUnit)
 }
 

--- a/Steps4Impact/Journey/Cells/JourneyDetailCell.swift
+++ b/Steps4Impact/Journey/Cells/JourneyDetailCell.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol JourneyDetailDelegate: class {
+protocol JourneyDetailDelegate: AnyObject {
   func didGetShareText(_ shareText: String)
 }
 

--- a/Steps4Impact/Journey/Cells/MilestoneCell.swift
+++ b/Steps4Impact/Journey/Cells/MilestoneCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol MilestoneNameButtonDelegate: class {
+protocol MilestoneNameButtonDelegate: AnyObject {
   func milestoneNameButtonTapped(sequence: Int)
 }
 

--- a/Steps4Impact/NotificationsV2/NotificationsPermissionView.swift
+++ b/Steps4Impact/NotificationsV2/NotificationsPermissionView.swift
@@ -30,7 +30,7 @@
 import Foundation
 import UIKit
 
-protocol NotificationPermissionCellDelegate: class {
+protocol NotificationPermissionCellDelegate: AnyObject {
   func turnOnNotifictions()
   func close()
 }

--- a/Steps4Impact/Protocols/Cells.swift
+++ b/Steps4Impact/Protocols/Cells.swift
@@ -33,11 +33,11 @@ protocol CellContext: Context {
   var identifier: String { get }
 }
 
-protocol ConfigurableCell: class {
+protocol ConfigurableCell: AnyObject {
   func configure(context: CellContext)
 }
 
-protocol ReusableCell: class {
+protocol ReusableCell: AnyObject {
   static var identifier: String { get }
 }
 

--- a/Steps4Impact/Protocols/Keyboardable.swift
+++ b/Steps4Impact/Protocols/Keyboardable.swift
@@ -30,7 +30,7 @@
 import UIKit
 import SnapKit
 
-protocol Keyboardable: class {
+protocol Keyboardable: AnyObject {
   func addKeyboardNotifications()
   func removeKeyboardNotifications()
   func keyboardChanged(notification: Foundation.Notification)

--- a/Steps4Impact/Settings/Cells/AppInfoCell.swift
+++ b/Steps4Impact/Settings/Cells/AppInfoCell.swift
@@ -36,7 +36,7 @@ struct AppInfoCellContext: CellContext {
   let body: String
 }
 
-protocol AppInfoCellDelegate: class {
+protocol AppInfoCellDelegate: AnyObject {
   func appInfoCellToggleStaging()
 }
 

--- a/Steps4Impact/Settings/Cells/ConnectSourceCell.swift
+++ b/Steps4Impact/Settings/Cells/ConnectSourceCell.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol ConnectSourceCellDelegate: class {
+protocol ConnectSourceCellDelegate: AnyObject {
   func updateSource(context: Context?)
 }
 

--- a/Steps4Impact/Settings/Cells/SettingsActionCell.swift
+++ b/Steps4Impact/Settings/Cells/SettingsActionCell.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol SettingsActionCellDelegate: class {
+protocol SettingsActionCellDelegate: AnyObject {
   func settingsActionCellTapped(context: Context?, button: UIButton)
 }
 

--- a/Steps4Impact/Settings/Cells/SettingsSwitchCell.swift
+++ b/Steps4Impact/Settings/Cells/SettingsSwitchCell.swift
@@ -29,7 +29,7 @@
 
 import UIKit
 
-protocol SettingsSwitchCellDelegate: class {
+protocol SettingsSwitchCellDelegate: AnyObject {
   func settingsSwitchToggled(toggled: Bool, context: Context?)
 }
 

--- a/Steps4Impact/Settings/Cells/TeamSettingsHeaderCell.swift
+++ b/Steps4Impact/Settings/Cells/TeamSettingsHeaderCell.swift
@@ -36,7 +36,7 @@ struct TeamSettingsHeaderCellContext: CellContext {
   let isLead: Bool
 }
 
-protocol TeamSettingsHeaderCellDelegate: class {
+protocol TeamSettingsHeaderCellDelegate: AnyObject {
   func editImageButtonPressed(cell: TeamSettingsHeaderCell)
 }
 

--- a/Steps4Impact/Settings/Cells/TeamSettingsMemberCell.swift
+++ b/Steps4Impact/Settings/Cells/TeamSettingsMemberCell.swift
@@ -57,7 +57,7 @@ struct TeamSettingsMemberCellContext: CellContext {
   }
 }
 
-protocol TeamSettingsMemberCellDelegate: class {
+protocol TeamSettingsMemberCellDelegate: AnyObject {
   func removeTapped(context: Context?, button: UIButton)
 }
 

--- a/Steps4Impact/Settings/TeamSettingsDataSource.swift
+++ b/Steps4Impact/Settings/TeamSettingsDataSource.swift
@@ -40,7 +40,7 @@ enum TeamMembersContext: Context {
   case remove(fbid: String, name: String)
 }
 
-protocol TeamSettingsDataSourceDelegate: class {
+protocol TeamSettingsDataSourceDelegate: AnyObject {
   func updated(team: Team?)
 }
 


### PR DESCRIPTION
`class` conformance has been replaced by conformance to `AnyObject`.
This cleans up a warning (error) due to the source breaking changes to
Swift.  This is required to build the project with a newer Xcode release
and SDK.