### PR TITLE
Pods: add a workaround for newer Swift releases

### DIFF
--- a/Pods/Target Support Files/Nimble/Nimble.debug.xcconfig
+++ b/Pods/Target Support Files/Nimble/Nimble.debug.xcconfig
@@ -5,7 +5,7 @@ ENABLE_BITCODE = NO
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 LIBRARY_SEARCH_PATHS = $(inherited) "$(PLATFORM_DIR)/Developer/usr/lib"
-OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak-lswiftXCTest -weak_framework "XCTest"
+OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak_framework "XCTest"
 OTHER_SWIFT_FLAGS = $(inherited) -D COCOAPODS -suppress-warnings
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)

--- a/Pods/Target Support Files/Nimble/Nimble.release.xcconfig
+++ b/Pods/Target Support Files/Nimble/Nimble.release.xcconfig
@@ -5,7 +5,7 @@ ENABLE_BITCODE = NO
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
 LIBRARY_SEARCH_PATHS = $(inherited) "$(PLATFORM_DIR)/Developer/usr/lib"
-OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak-lswiftXCTest -weak_framework "XCTest"
+OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak_framework "XCTest"
 OTHER_SWIFT_FLAGS = $(inherited) -D COCOAPODS -suppress-warnings
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)

--- a/Pods/Target Support Files/Nimble/Nimble.xcconfig
+++ b/Pods/Target Support Files/Nimble/Nimble.xcconfig
@@ -4,7 +4,7 @@ DEFINES_MODULE = YES
 ENABLE_BITCODE = NO
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak-lswiftXCTest -weak_framework "XCTest"
+OTHER_LDFLAGS = $(inherited) -Xlinker -no_application_extension -weak_framework "XCTest"
 OTHER_SWIFT_FLAGS = $(inherited) -D COCOAPODS -suppress-warnings
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)


### PR DESCRIPTION
Rely on the autolinking for the swiftXCTest dependency.  This manually
adjusts the pod xcconfig files to drop the explicit weak linking for the
library.  This allows us to repair the build until we update the pods.