### PR TITLE
Login: correct login flow for new user registration

### DIFF
--- a/Steps4Impact/LoginV2/LoginV2ViewController.swift
+++ b/Steps4Impact/LoginV2/LoginV2ViewController.swift
@@ -153,16 +153,16 @@ class LoginV2ViewController: ViewController {
 extension LoginV2ViewController {
   private func linkAKFBackend(fbid: String) -> Bool {
     var linked: Bool = false
-    AKFCausesService.getParticipant(fbid: fbid) { [weak self] (result) in
-      guard result.isSuccess else {
-        AKFCausesService.createParticipant(fbid: fbid) { [weak self] (result) in
-          guard result.isSuccess else {
-            self?.alert(message: "Sign In failed. Please try again")
-            return
-          }
+    AKFCausesService.getParticipant(fbid: fbid) { (result) in
+      linked = result.isSuccess
+      if !linked {
+        AKFCausesService.createParticipant(fbid: fbid) { (result) in
+          linked = result.isSuccess
         }
       }
-      linked = true
+    }
+    if !linked {
+      self.alert(message: "Sign In failed. Please try again")
     }
     return linked
   }


### PR DESCRIPTION
The `getParticipant` end point will not create the user in the case that
the user does not already exist and returns an error if the user has not
been created.  If we fail to get the participant, we should create users
explicitly.  Adjust the login behaviour to match this expectation.